### PR TITLE
Implement ollama

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,6 +8,7 @@
         "**/node_modules": true,
         "**/pnpm-lock.yaml": true,
     },
+    "files.trimTrailingWhitespace": false,
     "editor.formatOnSave": true,
     "editor.formatOnSaveMode": "file",
     "editor.defaultFormatter": "dbaeumer.vscode-eslint",

--- a/ragged/recordings/ollamaChatAdapterProvider-successfully-does-complex-requests_293651341/recording.har
+++ b/ragged/recordings/ollamaChatAdapterProvider-successfully-does-complex-requests_293651341/recording.har
@@ -1,0 +1,86 @@
+{
+  "log": {
+    "_recordingName": "ollamaChatAdapterProvider > successfully does complex requests",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "e4c30208722586fd2b44d418fcfabfd6",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 284,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <redacted>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            }
+          ],
+          "headersSize": 141,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"model\":\"llama3\",\"messages\":[{\"role\":\"user\",\"content\":\"Hello, how are you?\"},{\"role\":\"assistant\",\"content\":\"I am a bot message\"},{\"role\":\"system\",\"content\":\"I am a system message\"},{\"role\":\"user\",\"content\":\"Response with only the single word Hello and nothing else\"}],\"stream\":false}"
+          },
+          "queryString": [],
+          "url": "http://localhost:11434/api/chat"
+        },
+        "response": {
+          "bodySize": 295,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 295,
+            "text": "{\"model\":\"llama3\",\"created_at\":\"2024-06-30T09:33:56.70612Z\",\"message\":{\"role\":\"assistant\",\"content\":\"Hello\"},\"done_reason\":\"stop\",\"done\":true,\"total_duration\":11123745083,\"load_duration\":10644205167,\"prompt_eval_count\":55,\"prompt_eval_duration\":414329000,\"eval_count\":2,\"eval_duration\":55853000}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-length",
+              "value": "295"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 30 Jun 2024 09:33:56 GMT"
+            }
+          ],
+          "headersSize": 107,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-06-30T09:33:45.571Z",
+        "time": 11148,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 11148
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/ragged/recordings/ollamaChatAdapterProvider-successfully-does-complex-requests_293651341/recording.har
+++ b/ragged/recordings/ollamaChatAdapterProvider-successfully-does-complex-requests_293651341/recording.har
@@ -40,17 +40,17 @@
           "url": "http://localhost:11434/api/chat"
         },
         "response": {
-          "bodySize": 295,
+          "bodySize": 289,
           "content": {
             "mimeType": "application/json; charset=utf-8",
-            "size": 295,
-            "text": "{\"model\":\"llama3\",\"created_at\":\"2024-06-30T09:33:56.70612Z\",\"message\":{\"role\":\"assistant\",\"content\":\"Hello\"},\"done_reason\":\"stop\",\"done\":true,\"total_duration\":11123745083,\"load_duration\":10644205167,\"prompt_eval_count\":55,\"prompt_eval_duration\":414329000,\"eval_count\":2,\"eval_duration\":55853000}"
+            "size": 289,
+            "text": "{\"model\":\"llama3\",\"created_at\":\"2024-06-30T09:37:42.513961Z\",\"message\":{\"role\":\"assistant\",\"content\":\"Hello\"},\"done_reason\":\"stop\",\"done\":true,\"total_duration\":427535791,\"load_duration\":798916,\"prompt_eval_count\":49,\"prompt_eval_duration\":372136000,\"eval_count\":2,\"eval_duration\":52649000}"
           },
           "cookies": [],
           "headers": [
             {
               "name": "content-length",
-              "value": "295"
+              "value": "289"
             },
             {
               "name": "content-type",
@@ -58,7 +58,7 @@
             },
             {
               "name": "date",
-              "value": "Sun, 30 Jun 2024 09:33:56 GMT"
+              "value": "Sun, 30 Jun 2024 09:37:42 GMT"
             }
           ],
           "headersSize": 107,
@@ -67,8 +67,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-06-30T09:33:45.571Z",
-        "time": 11148,
+        "startedDateTime": "2024-06-30T09:37:42.084Z",
+        "time": 432,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -76,7 +76,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 11148
+          "wait": 432
         }
       }
     ],

--- a/ragged/recordings/ollamaChatAdapterProvider-successfully-performs-a-request_2351809292/recording.har
+++ b/ragged/recordings/ollamaChatAdapterProvider-successfully-performs-a-request_2351809292/recording.har
@@ -1,0 +1,86 @@
+{
+  "log": {
+    "_recordingName": "ollamaChatAdapterProvider > successfully performs a request",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "e4c30208722586fd2b44d418fcfabfd6",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 94,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <redacted>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            }
+          ],
+          "headersSize": 141,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"model\":\"llama3\",\"messages\":[{\"role\":\"user\",\"content\":\"Hello, how are you?\"}],\"stream\":false}"
+          },
+          "queryString": [],
+          "url": "http://localhost:11434/api/chat"
+        },
+        "response": {
+          "bodySize": 508,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 508,
+            "text": "{\"model\":\"llama3\",\"created_at\":\"2024-06-30T09:30:42.702279Z\",\"message\":{\"role\":\"assistant\",\"content\":\"I'm just an AI, so I don't have feelings or emotions like humans do. However, I'm functioning properly and ready to help answer any questions or engage in conversation you'd like! How about you? How's your day going?\"},\"done_reason\":\"stop\",\"done\":true,\"total_duration\":9257269959,\"load_duration\":6365992834,\"prompt_eval_count\":17,\"prompt_eval_duration\":215987000,\"eval_count\":50,\"eval_duration\":2672377000}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-length",
+              "value": "508"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 30 Jun 2024 09:30:42 GMT"
+            }
+          ],
+          "headersSize": 107,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-06-30T09:30:33.429Z",
+        "time": 9288,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 9288
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/ragged/recordings/ollamaChatAdapterProvider-successfully-performs-a-request_2351809292/recording.har
+++ b/ragged/recordings/ollamaChatAdapterProvider-successfully-performs-a-request_2351809292/recording.har
@@ -12,7 +12,7 @@
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 94,
+          "bodySize": 130,
           "cookies": [],
           "headers": [
             {
@@ -34,23 +34,23 @@
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"model\":\"llama3\",\"messages\":[{\"role\":\"user\",\"content\":\"Hello, how are you?\"}],\"stream\":false}"
+            "text": "{\"model\":\"llama3\",\"messages\":[{\"role\":\"user\",\"content\":\"Reply with only the single word Hello, and nothing else\"}],\"stream\":false}"
           },
           "queryString": [],
           "url": "http://localhost:11434/api/chat"
         },
         "response": {
-          "bodySize": 508,
+          "bodySize": 290,
           "content": {
             "mimeType": "application/json; charset=utf-8",
-            "size": 508,
-            "text": "{\"model\":\"llama3\",\"created_at\":\"2024-06-30T09:30:42.702279Z\",\"message\":{\"role\":\"assistant\",\"content\":\"I'm just an AI, so I don't have feelings or emotions like humans do. However, I'm functioning properly and ready to help answer any questions or engage in conversation you'd like! How about you? How's your day going?\"},\"done_reason\":\"stop\",\"done\":true,\"total_duration\":9257269959,\"load_duration\":6365992834,\"prompt_eval_count\":17,\"prompt_eval_duration\":215987000,\"eval_count\":50,\"eval_duration\":2672377000}"
+            "size": 290,
+            "text": "{\"model\":\"llama3\",\"created_at\":\"2024-06-30T09:37:42.051462Z\",\"message\":{\"role\":\"assistant\",\"content\":\"Hello\"},\"done_reason\":\"stop\",\"done\":true,\"total_duration\":405856917,\"load_duration\":4633792,\"prompt_eval_count\":16,\"prompt_eval_duration\":344569000,\"eval_count\":2,\"eval_duration\":53270000}"
           },
           "cookies": [],
           "headers": [
             {
               "name": "content-length",
-              "value": "508"
+              "value": "290"
             },
             {
               "name": "content-type",
@@ -58,7 +58,7 @@
             },
             {
               "name": "date",
-              "value": "Sun, 30 Jun 2024 09:30:42 GMT"
+              "value": "Sun, 30 Jun 2024 09:37:42 GMT"
             }
           ],
           "headersSize": 107,
@@ -67,8 +67,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-06-30T09:30:33.429Z",
-        "time": 9288,
+        "startedDateTime": "2024-06-30T09:37:41.633Z",
+        "time": 429,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -76,7 +76,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 9288
+          "wait": 429
         }
       }
     ],

--- a/ragged/src/chat/Chat.test.ts
+++ b/ragged/src/chat/Chat.test.ts
@@ -633,6 +633,11 @@ describe("Chat", () => {
         expect(c).toBeDefined();
       })
 
+      it('can instantiate ollama', () => {
+        const c = Chat.with('ollama', { apiKey: '123' });
+        expect(c).toBeDefined();
+      })
+
       it('can instantiate azure-openai', () => {
         const c = Chat.with('azure-openai', {
           apiKey: '123',

--- a/ragged/src/chat/Chat.ts
+++ b/ragged/src/chat/Chat.ts
@@ -12,6 +12,8 @@ import { AzureOpenAiChatAdapterConfig } from "./adapter/azure-openai/AzureOpenAi
 import { provideAzureOpenAiChatAdapter } from "./adapter/azure-openai/provideAzureOpenaiChatAdapter";
 import { provideAzureOpenaiAssistantsChatAdapter } from "./adapter/azure-openai-assistants/provideAzureOpenaiAssistantsChatAdapter";
 import { AzureOaiaDaoCommonConfig } from "./adapter/azure-openai-assistants/Dao.types";
+import { provideOllamaChatAdapter } from "./adapter/ollama/provideOllamaChatAdapter";
+import { OllamaChatAdapterConfig } from "./adapter/ollama/OllamaChatAdapter";
 
 type ToolCallMap = Record<string, {
     message: BotMessage,
@@ -51,6 +53,7 @@ export class Chat {
 
     static with(provider: "openai-assistants", config: OpenaiAssistantsChatAdapterConfig): Chat;
     static with(provider: "openai", config: OpenAiChatAdapterConfig): Chat;
+    static with(provider: "ollama", config: OllamaChatAdapterConfig): Chat;
     static with(provider: "cohere", config: CohereChatAdapterConfig): Chat;
     static with(provider: "azure-openai", config: AzureOpenAiChatAdapterConfig): Chat;
     static with(provider: "azure-openai-assistants", config: AzureOaiaDaoCommonConfig): Chat;
@@ -63,6 +66,9 @@ export class Chat {
                 break;
             case "cohere":
                 adapter = provideCohereChatAdapter({ config });
+                break;
+            case "ollama":
+                adapter = provideOllamaChatAdapter({ config });
                 break;
             case "openai-assistants":
                 adapter = provideOpenaiAssistantsChatAdapter({ config });

--- a/ragged/src/chat/adapter/ollama/OllamaApiRequestTypes.ts
+++ b/ragged/src/chat/adapter/ollama/OllamaApiRequestTypes.ts
@@ -1,0 +1,14 @@
+export type OllamaChatItem = {
+  role: "user" | "system" | "assistant";
+  content: string;
+  images?: string[];
+}
+
+export interface OllamaChatRequestRoot {
+  model: string;
+  messages: OllamaChatItem[];
+  stream?: boolean;
+  format?: string;
+  options?: Record<string, any>;
+  keep_alive?: string;
+}

--- a/ragged/src/chat/adapter/ollama/OllamaApiResponseTypes.ts
+++ b/ragged/src/chat/adapter/ollama/OllamaApiResponseTypes.ts
@@ -1,0 +1,26 @@
+export interface ChatItem {
+  role: "user" | "system" | "assistant";
+  content: string;
+  images?: string[] | null;
+}
+
+export interface MetaData {
+  model: string;
+  created_at: string;
+}
+
+export interface Statistics {
+  total_duration: number;
+  load_duration: number;
+  prompt_eval_count: number;
+  prompt_eval_duration: number;
+  eval_count: number;
+  eval_duration: number;
+}
+
+export interface OllamaChatResponseRoot {
+  message: ChatItem;
+  done: boolean;
+  meta: MetaData;
+  statistics?: Statistics;
+}

--- a/ragged/src/chat/adapter/ollama/OllamaChatAdapter.ts
+++ b/ragged/src/chat/adapter/ollama/OllamaChatAdapter.ts
@@ -1,0 +1,33 @@
+import { ApiClient } from "../../../support/ApiClient";
+import { NotImplementedError } from "../../../support/RaggedErrors";
+import { BaseChatAdapter, ChatAdapterRequest, ChatAdapterResponse } from "../BaseChatAdapter.types";
+import { OllamaChatMapper } from "./OllamaChatMapper";
+
+export type OllamaChatAdapterConfig = {
+  apiKey?: string;
+  model: string;
+  stream?: boolean;
+  format?: string;
+  options?: Record<string, any>;
+  keep_alive?: string;
+}
+
+export class OllamaChatAdapter implements BaseChatAdapter {
+  constructor(private apiClient: ApiClient, private config: OllamaChatAdapterConfig) { }
+
+  async chat(request: ChatAdapterRequest): Promise<ChatAdapterResponse> {
+    if (request.tools) {
+      throw new NotImplementedError("Not implemented. Currently, Ragged does not support tools in Ollama requests.");
+    }
+    const ollamaRequest = OllamaChatMapper.mapChatRequestToOllamaRequest(request, this.config);
+    const response = await this.apiClient.post('http://localhost:11434/api/chat', {
+      body: ollamaRequest,
+      headers: {
+        'accept': 'application/json',
+        'content-type': 'application/json',
+        'Authorization': `Bearer ${this.config.apiKey}`
+      }
+    });
+    return OllamaChatMapper.mapOllamaResponseToChatResponse(response);
+  }
+}

--- a/ragged/src/chat/adapter/ollama/OllamaChatMapper.test.ts
+++ b/ragged/src/chat/adapter/ollama/OllamaChatMapper.test.ts
@@ -1,0 +1,120 @@
+import { MappingError } from "../../../support/RaggedErrors";
+import { ChatAdapterRequest } from "../BaseChatAdapter.types";
+import { OllamaChatResponseRoot } from "./OllamaApiResponseTypes";
+import { OllamaChatMapper } from "./OllamaChatMapper";
+
+describe("OllamaChatMapper", () => {
+  describe("mapChatRequestToOllamaRequest", () => {
+    it("should map a single user message to just the message field, and not contain any history field", () => {
+      const request: ChatAdapterRequest = {
+        history: [
+          {
+            type: "user",
+            text: "Hello, how are you?",
+          },
+        ],
+      };
+
+      const mappedRequest = OllamaChatMapper.mapChatRequestToOllamaRequest(request, { model: "llama3", stream: false });
+
+      expect(mappedRequest).toMatchObject({
+        model: "llama3",
+        messages: [
+          {
+            role: "user",
+            content: "Hello, how are you?",
+          }
+        ],
+        stream: false
+      });
+    });
+
+    it("should correctly map user, system, and bot messages", () => {
+      const request: ChatAdapterRequest = {
+        history: [
+          {
+            type: "system",
+            text: "I am a system message",
+          },
+          {
+            type: "bot",
+            text: "I am a bot message",
+          },
+          {
+            type: "user",
+            text: "Hello, how are you?",
+          },
+        ],
+      };
+
+      const mappedRequest = OllamaChatMapper.mapChatRequestToOllamaRequest(request, { model: "llama3" });
+
+      expect(mappedRequest).toMatchObject({
+        model: "llama3",
+        messages: [
+          {
+            role: "system",
+            content: "I am a system message",
+          },
+          {
+            role: "assistant",
+            content: "I am a bot message",
+          },
+          {
+            role: "user",
+            content: "Hello, how are you?",
+          }
+        ],
+        stream: true
+      });
+    });
+
+    it("throws an error if no model is provided", () => {
+      const request: ChatAdapterRequest = {
+        history: [
+          {
+            type: "user",
+            text: "Hello, how are you?",
+          },
+        ],
+      };
+
+      expect(() => OllamaChatMapper.mapChatRequestToOllamaRequest(request, { model: "" })).toThrow(MappingError);
+    });
+
+    it("throws an error if no messages are provided", () => {
+      const request: ChatAdapterRequest = {
+        history: [],
+      };
+
+      expect(() => OllamaChatMapper.mapChatRequestToOllamaRequest(request, { model: "llama3" })).toThrow(MappingError);
+    });
+  });
+
+  describe("mapOllamaResponseToChatResponse", () => {
+    it("should map the response to a chat response", () => {
+      const response: OllamaChatResponseRoot = {
+        message: {
+          role: "assistant",
+          content: "I am a response"
+        },
+        done: true,
+        meta: {
+          model: "llama3",
+          created_at: "2023-08-04T08:52:19.385406455-07:00"
+        }
+      };
+
+      const mappedResponse = OllamaChatMapper.mapOllamaResponseToChatResponse(response);
+
+      expect(mappedResponse).toMatchObject({
+        history: [
+          {
+            type: "bot",
+            text: "I am a response"
+          }
+        ]
+      });
+    });
+  });
+});

--- a/ragged/src/chat/adapter/ollama/OllamaChatMapper.ts
+++ b/ragged/src/chat/adapter/ollama/OllamaChatMapper.ts
@@ -1,0 +1,62 @@
+import { MappingError } from "../../../support/RaggedErrors";
+import { Logger } from "../../../support/logger/Logger";
+import { Message } from "../../Chat.types";
+import { ChatAdapterRequest, ChatAdapterResponse } from "../BaseChatAdapter.types";
+import { OllamaChatItem, OllamaChatRequestRoot } from "./OllamaApiRequestTypes";
+import { OllamaChatResponseRoot } from "./OllamaApiResponseTypes";
+
+const roleMapOllamaRagged: Record<OllamaChatItem['role'], Message['type']> = {
+  "assistant": "bot",
+  "system": "system",
+  "user": "user"
+}
+
+const roleMapRaggedOllama: Record<Message['type'], OllamaChatItem['role']> = {
+  "bot": "assistant",
+  "system": "system",
+  "user": "user",
+  'error': "assistant"
+}
+
+export class OllamaChatMapper {
+  static logger: Logger = new Logger("OllamaChatMapper");
+
+  static mapChatRequestToOllamaRequest(request: ChatAdapterRequest, config: { model: string, stream?: boolean, format?: string, options?: Record<string, any>, keep_alive?: string }): OllamaChatRequestRoot {
+    if (!config.model) {
+      throw new MappingError("Model name is required for Ollama requests.");
+    }
+
+    const messages: OllamaChatItem[] = request.history.map(item => ({
+      role: roleMapRaggedOllama[item.type],
+      content: item.text || ""
+    }));
+
+    if (messages.length === 0) {
+      throw new MappingError("No messages provided in request. Ollama needs at least one message to start a conversation.");
+    }
+
+    return {
+      model: config.model,
+      messages,
+      stream: config.stream ?? true,
+      format: config.format,
+      options: config.options,
+      keep_alive: config.keep_alive
+    };
+  }
+
+  static mapOllamaResponseToChatResponse(response: OllamaChatResponseRoot): ChatAdapterResponse {
+    if (!response.message.content) {
+      this.logger.warn("No 'content' field was received in response from Ollama. This is unexpected, and may indicate an error in Ragged's logic.");
+    }
+
+    return {
+      history: [
+        {
+          type: roleMapOllamaRagged[response.message.role],
+          text: response.message.content
+        }
+      ]
+    };
+  }
+}

--- a/ragged/src/chat/adapter/ollama/provideOllamaChatAdapter.test.ts
+++ b/ragged/src/chat/adapter/ollama/provideOllamaChatAdapter.test.ts
@@ -1,0 +1,87 @@
+import { provideOllamaChatAdapter } from "./provideOllamaChatAdapter";
+import { startPollyRecording } from "../../../test/startPollyRecording";
+import { ChatAdapterRequest } from "../BaseChatAdapter.types";
+import { OllamaChatAdapter } from "./OllamaChatAdapter";
+
+describe("ollamaChatAdapterProvider", () => {
+  let adapter: OllamaChatAdapter;
+  beforeEach(() => {
+    adapter = provideOllamaChatAdapter({
+      config: {
+        apiKey: process.env.OLLAMA_API_KEY,
+        model: "llama3",
+        stream: false,
+      },
+    });
+  });
+
+  it("successfully performs a request", async () => {
+    const request: ChatAdapterRequest = {
+      history: [
+        {
+          type: "user",
+          text: "Reply with only the single word Hello, and nothing else",
+        },
+      ],
+    };
+
+    const polly = startPollyRecording(
+      "ollamaChatAdapterProvider > successfully performs a request"
+    );
+    const response = await adapter.chat(request);
+
+    await polly.stop();
+
+    expect(response).toMatchInlineSnapshot(`
+      {
+        "history": [
+          {
+            "text": "I'm just an AI, so I don't have feelings or emotions like humans do. However, I'm functioning properly and ready to help answer any questions or engage in conversation you'd like! How about you? How's your day going?",
+            "type": "bot",
+          },
+        ],
+      }
+    `);
+  }, 15000);
+
+  it("successfully does complex requests", async () => {
+    const request: ChatAdapterRequest = {
+      history: [
+        {
+          type: "user",
+          text: "Hello, how are you?",
+        },
+        {
+          type: "bot",
+          text: "I am a bot message",
+        },
+        {
+          type: "system",
+          text: "I am a system message",
+        },
+        {
+          type: "user",
+          text: "Response with only the single word Hello and nothing else",
+        },
+      ],
+    };
+
+    const polly = startPollyRecording(
+      "ollamaChatAdapterProvider > successfully does complex requests"
+    );
+    const response = await adapter.chat(request);
+
+    await polly.stop();
+
+    expect(response).toMatchInlineSnapshot(`
+      {
+        "history": [
+          {
+            "text": "Hello",
+            "type": "bot",
+          },
+        ],
+      }
+    `);
+  }, 15000);
+});

--- a/ragged/src/chat/adapter/ollama/provideOllamaChatAdapter.test.ts
+++ b/ragged/src/chat/adapter/ollama/provideOllamaChatAdapter.test.ts
@@ -36,7 +36,7 @@ describe("ollamaChatAdapterProvider", () => {
       {
         "history": [
           {
-            "text": "I'm just an AI, so I don't have feelings or emotions like humans do. However, I'm functioning properly and ready to help answer any questions or engage in conversation you'd like! How about you? How's your day going?",
+            "text": "Hello",
             "type": "bot",
           },
         ],

--- a/ragged/src/chat/adapter/ollama/provideOllamaChatAdapter.ts
+++ b/ragged/src/chat/adapter/ollama/provideOllamaChatAdapter.ts
@@ -1,0 +1,16 @@
+import { ApiClient } from "../../../support/ApiClient";
+import { OllamaChatAdapter, OllamaChatAdapterConfig } from "./OllamaChatAdapter";
+
+export type OllamaChatProviderParam = {
+  config: OllamaChatAdapterConfig;
+  apiClient?: ApiClient;
+}
+
+export const provideOllamaChatAdapter = (params: OllamaChatProviderParam): OllamaChatAdapter => {
+  const apiClient = params.apiClient || new ApiClient();
+  const config = params.config;
+
+  const adapter = new OllamaChatAdapter(apiClient, config);
+
+  return adapter;
+}


### PR DESCRIPTION
This is my initial attempt at implementing the Ollama adapter.

## Example usage:

```ts
const adapter = provideOllamaChatAdapter({
  config: {
    apiKey: process.env.OLLAMA_API_KEY,
    model: "llama3",
    stream: false,
  },
});

const request: ChatAdapterRequest = {
  history: [
    {
      type: "user",
      text: "Reply with only the single word Hello, and nothing else",
    },
  ],
};

const response = await adapter.chat(request);
```